### PR TITLE
Fix pWaitDstStageMask in vkQueueSubmit

### DIFF
--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -1582,7 +1582,7 @@ void idRenderBackend::GL_EndFrame() {
 	VkSemaphore * acquire = &vkcontext.acquireSemaphores[ vkcontext.currentFrameData ];
 	VkSemaphore * finished = &vkcontext.renderCompleteSemaphores[ vkcontext.currentFrameData ];
 
-	VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+	VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
 	VkSubmitInfo submitInfo = {};
 	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;


### PR DESCRIPTION
To make sure the image acquired semaphore is signaled before any pixels are rendered to the swapchain image we need to wait at VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT instead of VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT.