### PR TITLE
Fix idVulkanBlock::Free

### DIFF
--- a/neo/renderer/Vulkan/Allocator_VK.cpp
+++ b/neo/renderer/Vulkan/Allocator_VK.cpp
@@ -370,6 +370,8 @@ void idVulkanBlock::Free( vulkanAllocation_t & allocation ) {
 		return;
 	}
 
+	current->type = VULKAN_ALLOCATION_TYPE_FREE;
+
 	if ( current->prev && current->prev->type == VULKAN_ALLOCATION_TYPE_FREE ) {
 		chunk_t * prev = current->prev;
 


### PR DESCRIPTION
I believe that setting memory chunk to free type is missing in idVulkanBlock::Free method.
Without this memory is not always reclaimed. Eg when next chunk is free then it should be merged with the current one (and it is happening) but that current chunk isn't marked as a free (so it cannot be reused).
Another case: when a given allocation is deleted and corresponding to it chunk_t is not marked as free and adjacent chunks (prev and next) aren't also free then memory is lost (though total block's memory count - m_allocated - is decreased, still there is no chunk in the list with a sufficient memory count).