### PR TITLE
Add a renderpass object to avoid corrupting in GL_CopyFrameBuffer

### DIFF
--- a/neo/renderer/RenderBackend.h
+++ b/neo/renderer/RenderBackend.h
@@ -154,6 +154,7 @@ struct vulkanContext_t {
 
 	VkFormat						depthFormat;
 	VkRenderPass					renderPass;
+	VkRenderPass					renderPassResume;
 	VkPipelineCache					pipelineCache;
 	VkSampleCountFlagBits			sampleCount;
 	bool							supersampling;

--- a/neo/renderer/Vulkan/RenderBackend_VK.cpp
+++ b/neo/renderer/Vulkan/RenderBackend_VK.cpp
@@ -1016,6 +1016,19 @@ void idRenderBackend::CreateRenderPass() {
 	renderPassCreateInfo.dependencyCount = 0;
 
 	ID_VK_CHECK( vkCreateRenderPass( vkcontext.device, &renderPassCreateInfo, NULL, &vkcontext.renderPass ) );
+
+	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+	attachments[0].initialLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+	VkRenderPassCreateInfo renderPassResumeCreateInfo = {};
+	renderPassResumeCreateInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+	renderPassResumeCreateInfo.attachmentCount = resolve ? 3 : 2;
+	renderPassResumeCreateInfo.pAttachments = attachments;
+	renderPassResumeCreateInfo.subpassCount = 1;
+	renderPassResumeCreateInfo.pSubpasses = &subpass;
+	renderPassResumeCreateInfo.dependencyCount = 0;
+
+	ID_VK_CHECK(vkCreateRenderPass(vkcontext.device, &renderPassResumeCreateInfo, NULL, &vkcontext.renderPassResume));
 }
 
 /*
@@ -1267,6 +1280,9 @@ void idRenderBackend::Shutdown() {
 
 	// Destroy Render Pass
 	vkDestroyRenderPass( vkcontext.device, vkcontext.renderPass, NULL );
+
+	// Destroy Render Pass
+	vkDestroyRenderPass(vkcontext.device, vkcontext.renderPassResume, NULL);
 
 	// Destroy Render Targets
 	DestroyRenderTargets();
@@ -1731,8 +1747,8 @@ void idRenderBackend::GL_CopyFrameBuffer( idImage * image, int x, int y, int ima
 	}
 
 	VkRenderPassBeginInfo renderPassBeginInfo = {};
-	renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-	renderPassBeginInfo.renderPass = vkcontext.renderPass;
+	renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;	
+	renderPassBeginInfo.renderPass = vkcontext.renderPassResume;
 	renderPassBeginInfo.framebuffer = m_frameBuffers[ m_currentSwapIndex ];
 	renderPassBeginInfo.renderArea.extent = m_swapchainExtent;
 


### PR DESCRIPTION
Add a renderpass object to avoid corrupting in GL_CopyFrameBuffer …

This fixes the undefined behavior,  where renderpass with loadOp == DONT_CARE
and initialLayout == UNDEFINED was  re-started in GL_CopyFrameBuffer.  As the
framebuffer already was filled with data from before GL_CopyFrameBuffer,
this data was corrupted in vkCmdBeginRenderpass.

To avoid that, another renderpass object is created with loadOp == LOAD and proper
initialLayout is created and used in and after GL_CopyFrameBuffer.

Fixes #24

Authored-by: Lesniewska, Anna <Anna.Lesniewska@intel.com>